### PR TITLE
fix(ui-sse)!: enhance realtime UI with polished SSE handling and rendering

### DIFF
--- a/agents/summarizer.py
+++ b/agents/summarizer.py
@@ -9,6 +9,7 @@ import random
 import re
 import shutil
 import sys
+import time
 import traceback
 from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
@@ -313,6 +314,9 @@ class Summarizer:
         last_emit_time = 0
         emit_interval = 0.3  # Also limit to ~3 updates/sec
 
+        eval_start_time = None
+        first_token_time = None
+
         # Emit prompt assembly step
         self._update_queue.publish({
             "type": "step_update",
@@ -333,6 +337,7 @@ class Summarizer:
                 )
 
             # Emit LLM generation started
+            eval_start_time = time.time()
             self._update_queue.publish({
                 "type": "step_update",
                 "phase": {"id": phase_id},
@@ -340,6 +345,14 @@ class Summarizer:
             })
 
             for t, s in gen:
+                if first_token_time is None:
+                    first_token_time = time.time()
+                    eval_time_ms = (first_token_time - eval_start_time) * 1000
+                    self._update_queue.publish({
+                        "type": "step_update",
+                        "phase": {"id": phase_id},
+                        "step": {"id": step_id, "message": f"First token ({eval_time_ms:.0f}ms eval time)"},
+                    })
                 if shared.stop_everything:
                     self._update_queue.publish({
                         "type": "step_done",
@@ -351,8 +364,7 @@ class Summarizer:
                 stop = s
 
                 # Stream tokens to SSE (throttled)
-                import time as _time
-                now = _time.time()
+                now = time.time()
                 if len(text) - last_emit_len >= emit_threshold and now - last_emit_time >= emit_interval:
                     snippet = text[last_emit_len:]
                     if snippet:

--- a/script.py
+++ b/script.py
@@ -36,8 +36,8 @@ from .utils.helpers import (
 params = {
     "display_name": "DSS",
     "is_tab": True,
-    "sse_internal_port": 7880,
-    "sse_external_path": ":7880",
+    "sse_internal_port": 7870,
+    "sse_external_path": ":7870",
 }
 
 
@@ -264,7 +264,7 @@ def ensure_background_loop():
         _loop_thread.start()
 
 
-_sse_port = 7880  # Default SSE port
+_sse_port = 7870  # Default SSE port
 
 
 def setup():
@@ -376,7 +376,7 @@ def custom_js():
             autoescape=select_autoescape(['js', 'j2'])
         )
         template = env.get_template("ui.js.j2")
-        return template.render(sse_external_path=params.get("sse_external_path", ":7880"))
+        return template.render(sse_external_path=params.get("sse_external_path", ":7870"))
     except TemplateError as e:
         print(f"{_ERROR}Failed to load ui.js.j2: {e}{_RESET}")
         return ""

--- a/ui/sse_server.py
+++ b/ui/sse_server.py
@@ -169,12 +169,15 @@ class SSEServer:
 
                 while parent._running:
                     events = parent._queue.get_buffered_events()
-                    if len(events) > last_event_count:
+                    current_count = len(events)
+                    if current_count < last_event_count:  # Buffer was cleared
+                        last_event_count = 0
+                    if current_count > last_event_count:
                         for event_json in events[last_event_count:]:
                             if not self._send_event(event_json):
                                 print(f"[DSS SSE] Client disconnected")
                                 return
-                        last_event_count = len(events)
+                        last_event_count = current_count
                         last_heartbeat = time.time()
                     else:
                         # Heartbeat: send SSE comment to prevent timeout

--- a/ui/sse_server.py
+++ b/ui/sse_server.py
@@ -31,13 +31,13 @@ class SSEServer:
         GET /sse/dss-health  - Health check
     """
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 7880, queue=None):
+    def __init__(self, host: str = "127.0.0.1", port: int = 7870, queue=None):
         """
         Initialize the SSEServer with network binding and an update queue.
         
         Parameters:
         	host (str): IP address to bind the server to (default "127.0.0.1").
-        	port (int): TCP port to listen on (default 7880).
+        	port (int): TCP port to listen on (default 7870).
         	queue: Optional queue-like object supplying updates; if omitted, obtains the module default via `get_update_queue()`.
         
         Notes:
@@ -342,7 +342,7 @@ class SSEServer:
 _sse_server: SSEServer | None = None
 
 
-def get_sse_server(host: str = "127.0.0.1", port: int = 7880) -> SSEServer:
+def get_sse_server(host: str = "127.0.0.1", port: int = 7870) -> SSEServer:
     """
     Return the module-level singleton SSEServer, creating a new instance if none exists or the existing one is not running.
     
@@ -355,13 +355,13 @@ def get_sse_server(host: str = "127.0.0.1", port: int = 7880) -> SSEServer:
     return _sse_server
 
 
-def start_sse_server(host: str = "127.0.0.1", port: int = 7880) -> int:
+def start_sse_server(host: str = "127.0.0.1", port: int = 7870) -> int:
     """
     Start and return the configured SSE server's listening port.
     
     Parameters:
         host (str): Host address to bind the server to (default "127.0.0.1").
-        port (int): Preferred port to bind the server to (default 7880).
+        port (int): Preferred port to bind the server to (default 7870).
     
     Returns:
         int: The port the server is listening on, or `-1` if startup failed.

--- a/ui/sse_server.py
+++ b/ui/sse_server.py
@@ -175,7 +175,7 @@ class SSEServer:
                     if current_count > last_event_count:
                         for event_json in events[last_event_count:]:
                             if not self._send_event(event_json):
-                                print(f"[DSS SSE] Client disconnected")
+                                print("[DSS SSE] Client disconnected")
                                 return
                         last_event_count = current_count
                         last_heartbeat = time.time()

--- a/ui/ui.js.j2
+++ b/ui/ui.js.j2
@@ -26,6 +26,8 @@
     var msgCount = 0;
     var phases = {};
     var expandedMessages = {};
+    var topLevelCount = 0;
+    var subPhaseCount = 0;
 
     window.__dss = {
         phases: phases,
@@ -109,15 +111,19 @@
         var progressBar = document.getElementById('dss-progress-bar');
         var progressText = document.getElementById('dss-progress-text');
         var sessionInfo = document.getElementById('dss-session-info');
-        if (!phasesDiv) return;
 
         var type = ev.type;
         if (type === 'session_start') {
-            phasesDiv.innerHTML = '';
+            if (phasesDiv) phasesDiv.innerHTML = '';
             phases = {};
+            topLevelCount = 0;
+            subPhaseCount = 0;
             if (sessionInfo) sessionInfo.textContent = 'Summarization in progress...';
-            updateQueue(ev.queue, queueDiv);
-            updateProgress(ev.progress, progressBar, progressText);
+            if (queueDiv) updateQueue(ev.queue, queueDiv);
+            if (progressBar && progressText) updateProgress(ev.progress, progressBar, progressText);
+        } else if (!phasesDiv) {
+            // For other events, we need the phasesDiv to render
+            return;
         } else if (type === 'turn_start') {
             if (ev.turn && ev.turn > 1) {
                 var sep = document.createElement('div');
@@ -132,6 +138,11 @@
         } else if (type === 'phase_start') {
             var pid = ev.phase.id;
             phases[pid] = { name: ev.phase.name, steps: [], active: true };
+            if (pid.indexOf('.') === -1 && pid.indexOf('[') === -1) {
+                topLevelCount++;
+            } else {
+                subPhaseCount++;
+            }
             createPhaseElement(pid, ev.phase.name, phasesDiv);
             updateQueue(ev.queue, queueDiv);
         } else if (type === 'step_start') {
@@ -269,7 +280,10 @@
         if (!prog || !bar) return;
         var pct = prog.percent || 0;
         bar.style.width = pct + '%';
-        if (text) text.textContent = (prog.completed || 0) + '/' + (prog.total || 0) + ' (' + pct + '%)';
+        if (text) {
+            var subPhaseText = subPhaseCount ? (' <span style="color:#6e7681;">(' + subPhaseCount + ' sub-phases)</span>') : '';
+            text.innerHTML = (prog.completed || 0) + '/' + topLevelCount + ' (' + pct + '%)' + subPhaseText;
+        }
     }
 
     function getNestingDepth(pid) {

--- a/ui/ui.js.j2
+++ b/ui/ui.js.j2
@@ -635,7 +635,6 @@
                 if (phases[pid].steps[i].id === sid) { step = phases[pid].steps[i]; break; }
             }
         }
-        console.log(step, step.data, step.data.updates)
         if (step && step.data && step.data.updates) {
             dataDiv.innerHTML = renderUpdateList(step.data.updates, pid + '-' + sid + '-0', step.data.raw_json, pid, sid);
         }

--- a/ui/ui.js.j2
+++ b/ui/ui.js.j2
@@ -89,8 +89,7 @@
 
         eventSource.onmessage = function (e) {
             msgCount++;
-            console.log('[DSS SSE] #' + msgCount + ':', e.data.substring(0, 200));
-            if (debugEl) debugEl.textContent = 'Received ' + msgCount + ' events';
+            if (debugEl) { debugEl.textContent = 'Received ' + msgCount + ' events'; }
             try {
                 handleEvent(JSON.parse(e.data));
             } catch (err) {
@@ -115,11 +114,13 @@
 
         var type = ev.type;
         if (type === 'session_start') {
-            if (phasesDiv) phasesDiv.innerHTML = '';
             phases = {};
+            expandedMessages = {};
             topLevelIds = {};
             subPhaseCount = 0;
             topLevelProjection = 0;
+            if (phasesDiv) { phasesDiv.innerHTML = ''; }
+            if (queueDiv) { queueDiv.innerHTML = ''; }
             if (sessionInfo) sessionInfo.textContent = 'Summarization in progress...';
             if (queueDiv) updateQueue(ev.queue, queueDiv);
             if (progressBar && progressText) updateProgress(ev.progress, progressBar, progressText);
@@ -286,7 +287,6 @@
             }
             html += '<span style="display:inline-block;background:#21262d;padding:2px 8px;border-radius:4px;margin:2px;font-size:11px;color:#8b949e;">' + queue[i].name + '</span>';
         }
-        console.warn(`queue: ${queueTopLevel}`);
         topLevelProjection = queueTopLevel;
         queueDiv.innerHTML = html;
     }
@@ -294,7 +294,6 @@
     function updateProgress(prog, bar, text) {
         if (!prog || !bar) return;
         var completed = Object.keys(topLevelIds).length;
-        console.warn(`projection: ${topLevelProjection}`);
         var topLevelTotal = completed + topLevelProjection;
         if (completed === 0 && topLevelTotal === 0) { var pct = 0; }
         else { var pct = Math.floor(completed / topLevelTotal * 100); }

--- a/ui/ui.js.j2
+++ b/ui/ui.js.j2
@@ -26,8 +26,9 @@
     var msgCount = 0;
     var phases = {};
     var expandedMessages = {};
-    var topLevelCount = 0;
+    var topLevelIds = {};
     var subPhaseCount = 0;
+    var topLevelProjection = 0;
 
     window.__dss = {
         phases: phases,
@@ -116,8 +117,9 @@
         if (type === 'session_start') {
             if (phasesDiv) phasesDiv.innerHTML = '';
             phases = {};
-            topLevelCount = 0;
+            topLevelIds = {};
             subPhaseCount = 0;
+            topLevelProjection = 0;
             if (sessionInfo) sessionInfo.textContent = 'Summarization in progress...';
             if (queueDiv) updateQueue(ev.queue, queueDiv);
             if (progressBar && progressText) updateProgress(ev.progress, progressBar, progressText);
@@ -139,7 +141,7 @@
             var pid = ev.phase.id;
             phases[pid] = { name: ev.phase.name, steps: [], active: true };
             if (pid.indexOf('.') === -1 && pid.indexOf('[') === -1) {
-                topLevelCount++;
+                // Track as potential top-level on start, will be confirmed on done
             } else {
                 subPhaseCount++;
             }
@@ -244,6 +246,9 @@
             phases[pid].active = false;
             phases[pid].skipped = ev.phase.skipped;
             phases[pid].elapsed = ev.phase.elapsed;
+            if (pid.indexOf('.') === -1 && pid.indexOf('[') === -1) {
+                topLevelIds[pid] = true;
+            }
             markPhaseDone(pid, ev.phase.elapsed, ev.phase.skipped);
             updateQueue(ev.queue, queueDiv);
             updateProgress(ev.progress, progressBar, progressText);
@@ -255,6 +260,9 @@
             }
             phases[pid].active = false;
             phases[pid].error = ev.phase.error;
+            if (pid.indexOf('.') === -1 && pid.indexOf('[') === -1) {
+                topLevelIds[pid] = true;
+            }
             markPhaseError(pid, ev.phase.error);
         } else if (type === 'session_separator') {
             var sep = document.createElement('div');
@@ -268,21 +276,32 @@
 
     function updateQueue(queue, queueDiv) {
         if (!queueDiv) return;
-        if (!queue || !queue.length) { queueDiv.innerHTML = '<span style="color:#484f58;">-</span>'; return; }
+        if (!queue || !queue.length) { topLevelProjection = 0; queueDiv.innerHTML = '<span style="color:#484f58;">-</span>'; return; }
         var html = '';
+        var queueTopLevel = 0;
         for (var i = 0; i < queue.length; i++) {
+            var pid = queue[i].id || '';
+            if (pid.indexOf('.') === -1 && pid.indexOf('[') === -1) {
+                queueTopLevel++;
+            }
             html += '<span style="display:inline-block;background:#21262d;padding:2px 8px;border-radius:4px;margin:2px;font-size:11px;color:#8b949e;">' + queue[i].name + '</span>';
         }
+        console.warn(`queue: ${queueTopLevel}`);
+        topLevelProjection = queueTopLevel;
         queueDiv.innerHTML = html;
     }
 
     function updateProgress(prog, bar, text) {
         if (!prog || !bar) return;
-        var pct = prog.percent || 0;
+        var completed = Object.keys(topLevelIds).length;
+        console.warn(`projection: ${topLevelProjection}`);
+        var topLevelTotal = completed + topLevelProjection;
+        if (completed === 0 && topLevelTotal === 0) { var pct = 0; }
+        else { var pct = Math.floor(completed / topLevelTotal * 100); }
         bar.style.width = pct + '%';
         if (text) {
             var subPhaseText = subPhaseCount ? (' <span style="color:#6e7681;">(' + subPhaseCount + ' sub-phases)</span>') : '';
-            text.innerHTML = (prog.completed || 0) + '/' + topLevelCount + ' (' + pct + '%)' + subPhaseText;
+            text.innerHTML = completed + '/' + topLevelTotal + ' (' + pct + '%)' + subPhaseText;
         }
     }
 
@@ -617,6 +636,7 @@
                 if (phases[pid].steps[i].id === sid) { step = phases[pid].steps[i]; break; }
             }
         }
+        console.log(step, step.data, step.data.updates)
         if (step && step.data && step.data.updates) {
             dataDiv.innerHTML = renderUpdateList(step.data.updates, pid + '-' + sid + '-0', step.data.raw_json, pid, sid);
         }


### PR DESCRIPTION
This PR introduces a couple polish improvements to the realtime UI system:
- Added per-generation prompt eval stopwatch timer
- Fixed progress text and bar - Separate progress for top-level phases and sub-phases
- Fixed multi-session instances - Properly publish start_session event and reset client buffer on new session

BREAKING CHANGE: Moves default listener port 7880 to 7870

*Note: This is a subset of polish changes from branch [feature/realtime-ui-v2](https://github.com/Th-Underscore/dayna_ss/tree/feature/realtime-ui-v2). Additional improvements are planned in follow-up PRs.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-token timing metrics to monitor response generation latency and surface "First token (...ms)" updates.

* **Bug Fixes**
  * Improved streaming reliability when the event queue is cleared or refreshed.
  * Fixed progress display logic to more accurately reflect top-level phases and sub-phase counts.

* **Chores**
  * Changed default SSE server port and related UI fallback from 7880 to 7870.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->